### PR TITLE
nodejs to 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     }
   ],
   "engines": {
-    "node": ">=12.x.x <=16.x.x",
+    "node": ">=12.x.x <=20.x.x",
     "npm": ">=6.0.0"
   },
   "license": "MIT"


### PR DESCRIPTION
As strapi now uses from 18 to 20 nodejs versions, we need to change this plugin version too.